### PR TITLE
add personal score to dashboard

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -547,8 +547,7 @@
               });
               // get "logged in" user's data (Caitlin)
               this.$http.get('https://bnr-emobot.herokuapp.com/users/caitlin').then(response => {
-                  //todo: uncomment this and delete dummy data once seed data is ready on server
-                //this.$set(this.$data, 'received', response.body.data.kudos.received);
+                 this.$set(this.$data, 'received', response.body.data.kudos.received);
               }, response => {
                 console.log(response);
               });
@@ -558,30 +557,7 @@
             "brilliant": [],
             "hardworking": [],
             "kind": [],
-            "received": [ //todo: delete dummy data once server is ready
-{
-"channel": "caption-call-internal",
-"description": "great client call",
-"from": "kristin",
-"to": "caitlin",
-"value_points": {
-"brilliant": 3,
-"hardworking": 0,
-"kind": 1
-}
-},
-{
-"channel": "caption-call-internal",
-"description": "great client call",
-"from": "jjustice",
-"to": "caitlin",
-"value_points": {
-"brilliant": 3,
-"hardworking": 0,
-"kind": 1
-}
-}
-],
+            "received": [],
           },
           computed: {
               total_kudos: function(){

--- a/pages/index.html
+++ b/pages/index.html
@@ -64,7 +64,7 @@
                                 <div>
                                     <p>
                                         <strong>Brilliant</strong>
-                                        <span class="pull-right text-muted">{{  }} Points</span>
+                                        <span class="pull-right text-muted">40 Points</span>
                                     </p>
                                     <div class="progress progress-striped active">
                                         <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">

--- a/pages/index.html
+++ b/pages/index.html
@@ -64,7 +64,7 @@
                                 <div>
                                     <p>
                                         <strong>Brilliant</strong>
-                                        <span class="pull-right text-muted">40 Points</span>
+                                        <span class="pull-right text-muted">{{  }} Points</span>
                                     </p>
                                     <div class="progress progress-striped active">
                                         <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
@@ -242,7 +242,7 @@
                                     <i class="glyphicon glyphicon-stats fa-5x"></i>
                                 </div>
                                 <div class="col-xs-9 text-right">
-                                    <div class="huge">120</div>
+                                    <div class="huge">{{ total_kudos.brilliant + total_kudos.hardworking + total_kudos.kind }}</div>
                                     <div>Total Score</div>
                                 </div>
                             </div>
@@ -264,7 +264,7 @@
                                     <i class="glyphicon glyphicon-education fa-5x"></i>
                                 </div>
                                 <div class="col-xs-9 text-right">
-                                    <div class="huge">40</div>
+                                    <div class="huge">{{ total_kudos.brilliant }}</div>
                                     <div>Brilliant</div>
                                 </div>
                             </div>
@@ -286,7 +286,7 @@
                                     <i class="fa fa-thumbs-up fa-5x"></i>
                                 </div>
                                 <div class="col-xs-9 text-right">
-                                    <div class="huge">20</div>
+                                    <div class="huge">{{ total_kudos.hardworking }}</div>
                                     <div>Hardworking</div>
                                 </div>
                             </div>
@@ -308,7 +308,7 @@
                                     <i class="fa fa-heart fa-5x"></i>
                                 </div>
                                 <div class="col-xs-9 text-right">
-                                    <div class="huge">60</div>
+                                    <div class="huge">{{ total_kudos.kind }}</div>
                                     <div>Kind</div>
                                 </div>
                             </div>
@@ -537,10 +537,17 @@
           el: '#app',
           mounted: function() {
             this.$nextTick(function() {
+              // get leaderboard data
               this.$http.get('https://bnr-emobot.herokuapp.com/leaderboard').then(response => {
                 this.$set(this.$data, 'brilliant', response.body.data.brilliant);
                 this.$set(this.$data, 'hardworking', response.body.data.hardworking);
                 this.$set(this.$data, 'kind', response.body.data.kind);
+              }, response => {
+                console.log(response);
+              });
+              // get "logged in" user's data (Caitlin)
+              this.$http.get('https://bnr-emobot.herokuapp.com/users/caitlin').then(response => {
+                //this.$set(this.$data, 'received', response.body.data.kudos.received);
               }, response => {
                 console.log(response);
               });
@@ -549,7 +556,46 @@
           data: {
             "brilliant": [],
             "hardworking": [],
-            "kind": []
+            "kind": [],
+            "received": [
+{
+"channel": "caption-call-internal",
+"description": "great client call",
+"from": "kristin",
+"to": "caitlin",
+"value_points": {
+"brilliant": 3,
+"hardworking": 0,
+"kind": 1
+}
+},
+{
+"channel": "caption-call-internal",
+"description": "great client call",
+"from": "jjustice",
+"to": "caitlin",
+"value_points": {
+"brilliant": 3,
+"hardworking": 0,
+"kind": 1
+}
+}
+],
+          },
+          computed: {
+              total_kudos: function(){
+                var received_totals = {
+                    "brilliant": 0, 
+                    "hardworking": 0,
+                    "kind": 0,
+                };
+                return this.received.reduce(function(prev, kudo){
+                    received_totals.brilliant += kudo.value_points.brilliant;
+                    received_totals.hardworking += kudo.value_points.hardworking;
+                    received_totals.kind += kudo.value_points.kind;                    
+                    return received_totals;
+                },received_totals);
+              }
           }
         })
     </script>

--- a/pages/index.html
+++ b/pages/index.html
@@ -547,6 +547,7 @@
               });
               // get "logged in" user's data (Caitlin)
               this.$http.get('https://bnr-emobot.herokuapp.com/users/caitlin').then(response => {
+                  //todo: uncomment this and delete dummy data once seed data is ready on server
                 //this.$set(this.$data, 'received', response.body.data.kudos.received);
               }, response => {
                 console.log(response);
@@ -557,7 +558,7 @@
             "brilliant": [],
             "hardworking": [],
             "kind": [],
-            "received": [
+            "received": [ //todo: delete dummy data once server is ready
 {
 "channel": "caption-call-internal",
 "description": "great client call",


### PR DESCRIPTION
* Assumes logged in user is Caitlin
* Adds dummy data for "received" kudos (will replace this with server-provided data once seed data is deployed)
* Calculates total # of kudos by category based on user kudos data
* Sets totals in badges at top of screen